### PR TITLE
Check if process is undefined before emit warning to customize validator

### DIFF
--- a/src/suma2Text.js
+++ b/src/suma2Text.js
@@ -5,13 +5,13 @@ module.exports = function (
 
   if (languages) {
     languages.map(({ name, definitions }) => {
-      process.emitWarning(
-        `${name}: ${
-          textPackage[name]
+      if (process) 
+        process.emitWarning(
+          `${name}: ${textPackage[name]
             ? "will be custumized"
             : "it's not implemented, why do you wont make a pull request?"
-        }`
-      )
+          }`
+        )
 
       const newLanguage = textPackage[name]
         ? JSON.parse(JSON.stringify(textPackage[name]))


### PR DESCRIPTION
Added an if to check if process exists before emit warnings, fix refers to #28 